### PR TITLE
Fix typo in #include <WiFiUdp.h> & increasing turns per kWh limit

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -77,7 +77,7 @@
 // to make Arduino IDE happy
 // version number is set in platformio.ini
 #ifndef FIRMWARE_VERSION
-#define FIRMWARE_VERSION 220
+#define FIRMWARE_VERSION 221
 #endif
 
 // set default port for MQTT over TLS

--- a/include/index_de.h
+++ b/include/index_de.h
@@ -363,7 +363,7 @@ function checkInput() {
 
   if (document.getElementById("input_kwh_turns").value.length < 2 ||
     Number(document.getElementById("input_kwh_turns").value) < 50 ||
-    Number(document.getElementById("input_kwh_turns").value) > 500) {
+    Number(document.getElementById("input_kwh_turns").value) > 800) {
     document.getElementById("kwhError").style.display = "block";
     err++;
   }
@@ -488,7 +488,7 @@ function toggleHADiscovery() {
 <div style="max-width:335px;margin-top:10px;">
 <form method="POST" action="/config" onsubmit="return checkInput();">
   <fieldset><legend><b>&nbsp;Ferraris-Zähler&nbsp;</b></legend>
-  <p><b>KWh pro Umdrehung (50-500)</b><br />
+  <p><b>KWh pro Umdrehung (50-800)</b><br />
   <input id="input_kwh_turns" name="kwh_turns" size="16" maxlength="3" value="__TURNS_KWH__" onkeyup="digitsOnly(this);"></p>
   <p><b>Aktueller Zählerstand (KWh)</b><br />
   <input id="input_consumption_kwh" name="consumption_kwh" size="16" maxlength="9" value="__CONSUMPTION_KWH__" onkeyup="floatsOnly(this);"></p>

--- a/include/index_en.h
+++ b/include/index_en.h
@@ -363,7 +363,7 @@ function checkInput() {
 
   if (document.getElementById("input_kwh_turns").value.length < 2 ||
     Number(document.getElementById("input_kwh_turns").value) < 50 ||
-    Number(document.getElementById("input_kwh_turns").value) > 500) {
+    Number(document.getElementById("input_kwh_turns").value) > 800) {
     document.getElementById("kwhError").style.display = "block";
     err++;
   }
@@ -488,7 +488,7 @@ function toggleHADiscovery() {
 <div style="max-width:335px;margin-top:10px;">
 <form method="POST" action="/config" onsubmit="return checkInput();">
   <fieldset><legend><b>&nbsp;Ferraris Meter&nbsp;</b></legend>
-  <p><b>Turns per KWh (50-500)</b><br />
+  <p><b>Turns per KWh (50-800)</b><br />
   <input id="input_kwh_turns" name="kwh_turns" size="16" maxlength="3" value="__TURNS_KWH__" onkeyup="digitsOnly(this);"></p>
   <p><b>Current meter reading (KWh)</b><br />
   <input id="input_consumption_kwh" name="consumption_kwh" size="16" maxlength="9" value="__CONSUMPTION_KWH__" onkeyup="floatsOnly(this);"></p>

--- a/include/influx.h
+++ b/include/influx.h
@@ -15,7 +15,7 @@
 #define _INFLUX_H
 
 #include <Arduino.h>
-#include <WiFiUDP.h>
+#include <WiFiUdp.h>
 
 void send2influx_udp(uint16_t counter, uint16_t threshold, uint16_t pulse);
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@ default_envs = d1_mini
 description = Firmware for ESP8266 power meter
 
 [common]
-firmware_version = 220
+firmware_version = 221
 upload_speed = 460800
 monitor_speed = 115200
 port = /dev/tty.wchusbserial1410

--- a/src/web.cpp
+++ b/src/web.cpp
@@ -219,7 +219,7 @@ void startWebserver() {
 
     // save general settings
     httpServer.on("/config", HTTP_POST, []() {
-        if (httpServer.arg("kwh_turns").toInt() >= 50 && httpServer.arg("kwh_turns").toInt() <= 500)
+        if (httpServer.arg("kwh_turns").toInt() >= 50 && httpServer.arg("kwh_turns").toInt() <= 800)
             settings.turnsPerKwh = httpServer.arg("kwh_turns").toInt();
         if (httpServer.arg("consumption_kwh").toFloat() >= 1 && httpServer.arg("consumption_kwh").toFloat() <= 999999) {
             ferraris.consumption = httpServer.arg("consumption_kwh").toFloat();


### PR DESCRIPTION
Hi,

I fixed a typo in influx.h that caused compilation to fail with a no such file or directory error.

It's a bit weird that I'm the first to run into this problem. This probably has something to do with how different operating systems handle case sensitivity in file names...

Jelle