### PR TITLE
fixed unit of measurement on mqtt values for home assistant

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -81,7 +81,7 @@
 // to make Arduino IDE happy
 // version number is set in platformio.ini
 #ifndef FIRMWARE_VERSION
-#define FIRMWARE_VERSION 230
+#define FIRMWARE_VERSION 231
 #endif
 
 // set default port for MQTT over TLS

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@ default_envs = d1_mini
 description = Firmware for ESP8266 power meter
 
 [common]
-firmware_version = 230
+firmware_version = 231
 upload_speed = 460800
 monitor_speed = 115200
 port = /dev/tty.wchusbserial1410

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -138,7 +138,7 @@ static void publishHADiscoveryMessage(bool publish) {
 
         JSON["name"] = "WiFi Power Meter " + String(settings.systemID) + " WiFi Signal Strength";
         JSON["unique_id"] = "wifipowermeter-" + String(settings.systemID)+ "-rssi";
-        JSON["unit_of_meas"] = "dbm";
+        JSON["unit_of_meas"] = "dBm";
         JSON["dev_cla"] = "signal_strength";
         JSON["stat_t"] = devTopic;
         JSON["val_tpl"] = "{{ value_json."+ String(MQTT_SUBTOPIC_RSSI) +" }}";
@@ -155,6 +155,7 @@ static void publishHADiscoveryMessage(bool publish) {
 
         JSON["name"] = "WiFi Power Meter " + String(settings.systemID) + " Uptime";
         JSON["unique_id"] = "wifipowermeter-" + String(settings.systemID)+ "-uptime";
+        JSON["unit_of_meas"] = "d";
         JSON["ic"] = "mdi:clock-outline";
         JSON["dev_cla"] = "duration";
         JSON["stat_t"] = devTopic;

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -104,7 +104,7 @@ static void publishHADiscoveryMessage(bool publish) {
         "%s%s/runtime/config", MQTT_TOPIC_DISCOVER, systemID);
 
     if (publish) {
-        Serial.printf("Sending Home Asssistant MQTT discovery message for %s...\n", devTopic);
+        Serial.printf("Sending Home Assistant MQTT discovery message for %s...\n", devTopic);
 
         JSON["name"] = "WiFi Power Meter " + String(settings.systemID) + " Ferraris Impuls Counter";
         JSON["unique_id"] = "wifipowermeter-" + String(settings.systemID)+ "-impuls-counter";
@@ -166,7 +166,7 @@ static void publishHADiscoveryMessage(bool publish) {
 
     } else if (strlen(devTopic) > 1) {
         // send empty (retained) message to delete sensor autoconfiguration
-        Serial.printf("Removing Home Asssistant MQTT discovery message for %s...\n", devTopic);
+        Serial.printf("Removing Home Assistant MQTT discovery message for %s...\n", devTopic);
 
         mqtt->publish(topicCount, "", true);
         delay(50);


### PR DESCRIPTION
I saw in my home assistant log today that the sensor **wifi_power_meter_<id>_uptime** had no unit of measurement and that the sensor **sensor.wifi_power_meter_<id>_wifi_signal_strength** had "dbm" all lowercase instead of "dBm" as unit of measurment.

Both was complained as wrong in my log so I fixed it :)

Btw: Thank you for this amazing project, it works like a charm! :)